### PR TITLE
Handle log-level as case-insensitive

### DIFF
--- a/configurable_http_proxy/cli.py
+++ b/configurable_http_proxy/cli.py
@@ -126,7 +126,8 @@ class HeaderParamType(click.ParamType):
 @click.option(
     "--log-level",
     type=click.Choice(
-        [logging.getLevelName(i) for i in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR)]
+        [logging.getLevelName(i) for i in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR)],
+        case_sensitive=False,
     ),
     help='Log level (debug, info, warning, error) (default: "info")',
 )


### PR DESCRIPTION
JupyterHub passes `debug` when `c.ConfigurableHTTPProxy.debug=True` whereas `logging.DEBUG` is treated as `DEBUG`

https://github.com/jupyterhub/jupyterhub/blob/9d2ceaa1563bc9463cfd22d8d1abe07ebccd79e0/jupyterhub/proxy.py#L676-L677